### PR TITLE
[Fix #119711545] Remove die-dump debugger from code

### DIFF
--- a/app/Http/Middleware/ValidateComment.php
+++ b/app/Http/Middleware/ValidateComment.php
@@ -19,7 +19,6 @@ class ValidateComment
         $validator = $this->validateComment($request->all());
 
         if ($validator->fails()) {
-            dd($validator->messages());
             return redirect()->back()->withErrors($validator->messages());
         }
         return $next($request);


### PR DESCRIPTION
The dd debugger used is removed from the code.